### PR TITLE
Check alternative operators for "here be dragons"

### DIFF
--- a/lib/magritte.ex
+++ b/lib/magritte.ex
@@ -20,7 +20,7 @@ defmodule Magritte do
 
   This operator introduces the expression on the left hand as an argument to
   the function call on the right hand. The position for given argument is
-  determined by positopn of `...` operator on the right. If that operator
+  determined by positopn of `^_` operator on the right. If that operator
   is not present, then it will use first position as a default.
 
   ## Examples
@@ -36,7 +36,7 @@ defmodule Magritte do
   inserted:
 
   ```elixir
-  iex> 2 |> Integer.to_string(10, ...)
+  iex> 2 |> Integer.to_string(10, ^_)
   "1010"
   ```
 
@@ -45,16 +45,16 @@ defmodule Magritte do
   You can also join these into longer chains:
 
   ```elixir
-  iex> 2 |> Integer.to_string(10, ...) |> Integer.parse
+  iex> 2 |> Integer.to_string(10, ^_) |> Integer.parse
   {1010, ""}
   ```
 
-  The operator `...` can be used only once in the pipeline, otherwise
+  The operator `^_` can be used only once in the pipeline, otherwise
   it will return compile-time error:
 
   ```elixir
-  2 |> Integer.to_string(..., ...)
-  ** (CompileError) Doubled placeholder in Integer.to_string(..., ...)
+  2 |> Integer.to_string(^_, ^_)
+  ** (CompileError) Doubled placeholder in Integer.to_string(^_, ^_)
   ```
   """
   defmacro left |> right do
@@ -95,7 +95,7 @@ defmodule Magritte do
 
   defguardp is_empty(a) when a == [] or not is_list(a)
 
-  pattern = quote do: {:..., _, var!(args)}
+  pattern = quote do: {:^, _, [{:_, _, var!(args)}]}
 
   defp locate([unquote(pattern) | rest], pos, nil, acc) when is_empty(args),
     do: locate(rest, pos + 1, pos, acc)

--- a/test/magritte_test.exs
+++ b/test/magritte_test.exs
@@ -7,10 +7,10 @@ defmodule MagritteTest do
 
   doctest @subject
 
-  test "fails on doubled `...` operator" do
+  test "fails on doubled `^_` operator" do
     quoted =
       quote do
-        2 |> Integer.to_string(..., ...)
+        2 |> Integer.to_string(^_, ^_)
       end
 
     assert_raise CompileError, ~r"Doubled placeholder in Integer.to_string", fn ->
@@ -19,14 +19,14 @@ defmodule MagritteTest do
   end
 
   test "works with calls without parens" do
-    assert "1010" == (2 |> Integer.to_string(10, ...))
+    assert "1010" == (2 |> Integer.to_string(10, ^_))
   end
 
   test "multiple arguments are still passed as expected" do
     assert {1, 2, 3} == (1 |> id(2, 3))
-    assert {1, 2, 3} == (1 |> id(..., 2, 3))
-    assert {1, 2, 3} == (2 |> id(1, ..., 3))
-    assert {1, 2, 3} == (3 |> id(1, 2, ...))
+    assert {1, 2, 3} == (1 |> id(^_, 2, 3))
+    assert {1, 2, 3} == (2 |> id(1, ^_, 3))
+    assert {1, 2, 3} == (3 |> id(1, 2, ^_))
   end
 
   def id(a, b, c), do: {a, b, c}


### PR DESCRIPTION
Poll about the operator to be used (just click on the option you like, and your vote will be counted, **it will not bring you to the poll site**):

[![](https://api.gh-polls.com/poll/01EFEN4KSZHSSAERSTYTM0DXV8/%60...%60)](https://api.gh-polls.com/poll/01EFEN4KSZHSSAERSTYTM0DXV8/%60...%60/vote)
[![](https://api.gh-polls.com/poll/01EFEN4KSZHSSAERSTYTM0DXV8/%60%5E_%60)](https://api.gh-polls.com/poll/01EFEN4KSZHSSAERSTYTM0DXV8/%60%5E_%60/vote)
[![](https://api.gh-polls.com/poll/01EFEN4KSZHSSAERSTYTM0DXV8/%60%26_%60)](https://api.gh-polls.com/poll/01EFEN4KSZHSSAERSTYTM0DXV8/%60%26_%60/vote)
[![](https://api.gh-polls.com/poll/01EFEN4KSZHSSAERSTYTM0DXV8/Other%20(comment))](https://api.gh-polls.com/poll/01EFEN4KSZHSSAERSTYTM0DXV8/Other%20(comment)/vote)